### PR TITLE
Prevent read of _inB while it is 255

### DIFF
--- a/src/Toggle.cpp
+++ b/src/Toggle.cpp
@@ -27,7 +27,10 @@ void Toggle::poll(uint8_t bit) {
     us_timestamp += us_period;
     if (_inputMode == inputMode::input || _inputMode == inputMode::input_pullup || _inputMode == inputMode::input_pulldown) {
       if (_inA) dat = digitalRead(_inA);
-      if (_inB) dat += digitalRead(_inB) * 2;
+      // Prevent read of _inB spamming debug log if it wasn't set during begin()
+      if (_inB != 255) {
+         if (_inB) dat += digitalRead(_inB) * 2;
+      }
     }
     if (_inputMode == inputMode::input_byte) dat = *_in;
     if (getInputInvert()) dat = ~dat;


### PR DESCRIPTION
On ESP32 a digitalRead(255) will throw an error into the debug log.
If the poll loop is fast (which it should be), you get a _lot_ of those messages making the debug logs hard/impossible to use.
Adding a check to see if _inB was actually set at begin() time prevents this.